### PR TITLE
[ FIX ] add origintor when in node.js env.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [1.6.11 - 2025-07-05](#1611---2025-07-05)
 - [1.6.10 - 2025-07-02](#1610---2025-07-02)
 - [1.6.9 - 2025-07-02](#169---2025-07-02)
 - [1.6.8 - 2025-06-26](#168---2025-06-26)
@@ -139,6 +140,12 @@ All notable changes to this project will be documented in this file. The format 
 ### Security
 
 ---
+
+## [1.6.11] - 2025-07-05
+
+### Fixed
+
+- Fixed an edge-case where the originator header wasn't correctly set when in non-browser environments.
 
 ## [1.6.10] - 2025-07-02
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.6.10",
+      "version": "1.6.11",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^9.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/wallet/substrates/HTTPWalletJSON.ts
+++ b/src/wallet/substrates/HTTPWalletJSON.ts
@@ -54,7 +54,7 @@ export default class HTTPWalletJSON implements WalletInterface {
     this.httpClient = httpClient
 
     // Detect if we're in a browser environment
-    const isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined'
+    const isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined' && window?.origin !== 'file://'
 
     this.api = async (call: string, args: object) => {
       // In browser environments, let the browser handle Origin header automatically
@@ -63,6 +63,10 @@ export default class HTTPWalletJSON implements WalletInterface {
         ? toOriginHeader(this.originator, 'http')
         : undefined
 
+      if (!isBrowser && origin === undefined) {
+        console.error('Originator is required in Node.js environments')
+      }
+
       const res = await (
         await httpClient(`${this.baseUrl}/${call}`, {
           method: 'POST',
@@ -70,6 +74,7 @@ export default class HTTPWalletJSON implements WalletInterface {
             Accept: 'application/json',
             'Content-Type': 'application/json',
             ...(origin ? { Origin: origin } : {}),
+            ...(origin ? { Originator: origin } : {}),
           },
           body: JSON.stringify(args)
         })


### PR DESCRIPTION
## Description of Changes

Using origin !== “file://“ filters out ides which run esm node so they’re not falsely detected as browsers.

Also actively setting a header: Originator as well as Origin. Metanet desktop is expect that to be set.

## Linked Issues / Tickets

Closes #303

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged