### PR TITLE
update github repo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,17 @@ For a more detailed tutorial and advanced examples, check our [Documentation](#d
 ## Features & Deliverables
 
 - **Sound Cryptographic Primitives**: Secure key management, signature computations, and encryption protocols.
-  
+
 - **Script Level Constructs**: Network-compliant script interpreter with support for custom scripts and serialization formats.
-  
+
 - **Transaction Construction and Signing**: Comprehensive transaction builder API, ensuring versatile and secure transaction creation.
-  
+
 - **Transaction Broadcast Management**: Mechanisms to send transactions to both miners and overlays, ensuring extensibility and future-proofing.
-  
+
 - **Merkle Proof Verification**: Tools for representing and verifying merkle proofs, adhering to various serialization standards.
-  
+
 - **Serializable SPV Structures**: Structures and interfaces for full SPV verification.
-  
+
 - **Secure Encryption and Signed Messages**: Enhanced mechanisms for encryption and digital signatures, replacing outdated methods.
 
 - **P2P Authentication**: Robust peer-to-peer authentication mechanisms to ensure secure connections between parties.
@@ -92,11 +92,11 @@ For a more detailed tutorial and advanced examples, check our [Documentation](#d
 
 Comprehensive documentation is available in several formats:
 
-- **[📚 Online Documentation](https://bitcoin-sv.github.io/ts-sdk)**: Our complete documentation:
-    - **[🚀 Tutorials](https://bitcoin-sv.github.io/ts-sdk/tutorials/)**: Step-by-step lessons to learn by doing
-    - **[🔧 How-To Guides](https://bitcoin-sv.github.io/ts-sdk/guides/)**: Practical solutions to specific problems
-    - **[📚 Reference](https://bitcoin-sv.github.io/ts-sdk/reference/)**: Complete technical specifications and API documentation
-    - **[🏗️ Concepts](https://bitcoin-sv.github.io/ts-sdk/concepts/)**: Architecture and design explanations
+- **[📚 Online Documentation](https://bsv-blockchain.github.io/ts-sdk)**: Our complete documentation:
+    - **[🚀 Tutorials](https://bsv-blockchain.github.io/ts-sdk/tutorials/)**: Step-by-step lessons to learn by doing
+    - **[🔧 How-To Guides](https://bsv-blockchain.github.io/ts-sdk/guides/)**: Practical solutions to specific problems
+    - **[📚 Reference](https://bsv-blockchain.github.io/ts-sdk/reference/)**: Complete technical specifications and API documentation
+    - **[🏗️ Concepts](https://bsv-blockchain.github.io/ts-sdk/concepts/)**: Architecture and design explanations
 - **[⚡ Examples](https://docs.bsvblockchain.org/guides/sdks/ts/examples)**: Practical code examples
 - **Code Annotations**: The SDK is richly documented with code-level annotations that show up in editors like VSCode
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: BSV TypeScript SDK
 site_description: TypeScript SDK for Bitcoin SV
-site_url: https://bitcoin-sv.github.io/ts-sdk/
-repo_url: https://github.com/bitcoin-sv/ts-sdk
-repo_name: bitcoin-sv/ts-sdk
+site_url: https://bsv-blockchain.github.io/ts-sdk/
+repo_url: https://github.com/bsv-blockchain/ts-sdk
+repo_name: bsv-blockchain/ts-sdk
 
 theme:
   name: material

--- a/src/transaction/Beef.ts
+++ b/src/transaction/Beef.ts
@@ -21,18 +21,18 @@ export enum TX_DATA_FORMAT {
 
 /*
  * BEEF standard: BRC-62: Background Evaluation Extended Format (BEEF) Transactions
- * https://github.com/bitcoin-sv/BRCs/blob/master/transactions/0062.md
+ * https://github.com/bsv-blockchain/BRCs/blob/master/transactions/0062.md
  *
  * BUMP standard: BRC-74: BSV Unified Merkle Path (BUMP) Format
- * https://github.com/bitcoin-sv/BRCs/blob/master/transactions/0074.md
+ * https://github.com/bsv-blockchain/BRCs/blob/master/transactions/0074.md
  *
  * BRC-95: Atomic BEEF Transactions
- * https://github.com/bitcoin-sv/BRCs/blob/master/transactions/0095.md
+ * https://github.com/bsv-blockchain/BRCs/blob/master/transactions/0095.md
  *
  * The Atomic BEEF format is supported by the binary deserialization static method `fromBinary`.
  *
  * BRC-96: BEEF V2, Txid Only Extension
- * https://github.com/bitcoin-sv/BRCs/blob/master/transactions/0096.md
+ * https://github.com/bsv-blockchain/BRCs/blob/master/transactions/0096.md
  *
  * A valid serialized BEEF is the cornerstone of Simplified Payment Validation (SPV)
  * where they are exchanged between two non-trusting parties to establish the


### PR DESCRIPTION
fixes broken `https://github.com/bitcoin-sv/ts-sdk` links 
by replacing `bitcoin-sv` with `bsv-blockchain` in links.

---

Previous behavior:

User clicked

<img width="185" height="85" alt="image" src="https://github.com/user-attachments/assets/bfc46cce-e547-4fc5-a237-d298e46fca18" />


User got

<img width="355" height="297" alt="image" src="https://github.com/user-attachments/assets/7f193118-c364-4e21-85e9-3ddaf04fd8ab" />
