### PR TITLE
Fix SPV verification to handle invalid merkle paths properly

### DIFF
--- a/src/transaction/Transaction.ts
+++ b/src/transaction/Transaction.ts
@@ -804,6 +804,8 @@ export default class Transaction {
           if (proofValid) {
             verifiedTxids.add(txid)
             continue
+          } else {
+            throw new Error(`Invalid merkle path for transaction ${txid}`)
           }
         }
       }


### PR DESCRIPTION
## Description of Changes

Fix SPV verification logic to properly handle invalid merkle path validation. MerklePath.verify() returns false when validation fails (not an error), but the previous logic treated this as a fallback to input verification instead of a failure case. Invalid merkle paths now throw error immediately.

## Linked Issues / Tickets

None

## Testing Procedure

- [ ] I have added new unit tests
- [x] All tests pass locally  
- [x] I have tested manually in my local environment

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [ ] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged