### PR TITLE
Optimize Atomic BEEF performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,16 @@ All notable changes to this project will be documented in this file. The format 
 ### Security
 
 ---
+
+### [1.7.7] - 2025-09-19
+
+### Added
+
+- Atomic BEEF bemchmark for long chains
+- Performance enhancements when dealing with long BEEF chains
+
+---
+
 ### [1.7.6] - 2025-09-09
 
 ### Fixed

--- a/benchmarks/atomic-beef-bench.js
+++ b/benchmarks/atomic-beef-bench.js
@@ -1,0 +1,78 @@
+import { performance } from 'perf_hooks'
+import Transaction from '../dist/esm/src/transaction/Transaction.js'
+import PrivateKey from '../dist/esm/src/primitives/PrivateKey.js'
+import P2PKH from '../dist/esm/src/script/templates/P2PKH.js'
+
+async function buildChain (depth) {
+  const privateKey = new PrivateKey(1)
+  const publicKeyHash = privateKey.toPublicKey().toHash()
+  const p2pkh = new P2PKH()
+
+  const baseTx = new Transaction()
+  baseTx.addOutput({
+    lockingScript: p2pkh.lock(publicKeyHash),
+    satoshis: 100000
+  })
+
+  let currentTx = baseTx
+
+  for (let i = 1; i < depth; i++) {
+    const nextTx = new Transaction()
+    nextTx.addInput({
+      sourceTransaction: currentTx,
+      sourceOutputIndex: 0,
+      unlockingScriptTemplate: p2pkh.unlock(privateKey),
+      sequence: 0xffffffff
+    })
+    nextTx.addOutput({
+      lockingScript: p2pkh.lock(publicKeyHash),
+      satoshis: 100000 - i
+    })
+    await nextTx.sign()
+    currentTx = nextTx
+  }
+
+  return currentTx
+}
+
+async function measure (fn, iterations = 5) {
+  const times = []
+  for (let i = 0; i < iterations; i++) {
+    const start = performance.now()
+    const result = fn()
+    if (result instanceof Promise) {
+      await result
+    }
+    const end = performance.now()
+    times.push(end - start)
+  }
+  const total = times.reduce((sum, t) => sum + t, 0)
+  return {
+    average: total / times.length,
+    min: Math.min(...times),
+    max: Math.max(...times)
+  }
+}
+
+async function run () {
+  const depth = Number.parseInt(process.argv[2] ?? '200', 10)
+  const iterations = Number.parseInt(process.argv[3] ?? '5', 10)
+  console.log(`Building transaction chain with depth ${depth} ...`)
+  const finalTx = await buildChain(depth)
+
+  console.log('Warming up serializers/deserializers ...')
+  const initialSerialized = finalTx.toAtomicBEEF()
+  Transaction.fromAtomicBEEF(initialSerialized)
+
+  const toStats = await measure(() => finalTx.toAtomicBEEF(), iterations)
+  const serialized = finalTx.toAtomicBEEF()
+  const fromStats = await measure(() => Transaction.fromAtomicBEEF(serialized), iterations)
+
+  console.log(`Transaction.toAtomicBEEF avg: ${toStats.average.toFixed(2)}ms (min ${toStats.min.toFixed(2)}ms, max ${toStats.max.toFixed(2)}ms)`) 
+  console.log(`Transaction.fromAtomicBEEF avg: ${fromStats.average.toFixed(2)}ms (min ${fromStats.min.toFixed(2)}ms, max ${fromStats.max.toFixed(2)}ms)`) 
+}
+
+run().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.7.6",
+      "version": "1.7.7",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^9.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",


### PR DESCRIPTION
## Description of Changes

Added benchmarks for serializing and deserializing long chains of Atomic BEEF.

From Codex:

> Reworked Transaction.toBEEF to memoize BUMP lookups, deduplicate transactions with a set, and walk inputs in reverse order so serialization no longer spends quadratic time on long ancestry chains.
> Introduced a cached TXID index inside Beef and synchronized it across merges, removals, and trims to accelerate findTxid during Atomic BEEF deserialization.

- Without the optimizations serialization took 25ms, now it takes 1ms
- Without the optimizations deserialization took 4ms now it takes 3ms
- These stats are from an M3 Max MacBook Pro

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [x] I have added new benchmarks
- [x] All tests pass locally
- [x] I have benchmarked manually in my local environment

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged
